### PR TITLE
feat: Allow passing `data` option to sass

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,18 @@ export async function preprocessSass(
 ) {
   if (!filter(Object.assign({ name: 'sass' }, filterOptions), { attributes })) { return null; }
 
-  const { css, map } = await new Promise((resolve, reject) => sassCompiler.render(Object.assign({
-    file: filename,
-    data: content,
-    includePaths: [
-      dirname(filename),
-    ],
-  }, sassOptions), (err, result) => {
+  const { data, includePaths } = sassOptions;
+
+  const { css, map } = await new Promise((resolve, reject) => sassCompiler.render(Object.assign({},
+    sassOptions,
+    {
+      file: filename,
+      data: `${data ? `${data}
+` : ''}${content}`,
+      includePaths: (includePaths || []).concat([
+        dirname(filename),
+      ]),
+    }), (err, result) => {
     if (err) {
       reject(err);
     } else {

--- a/test/index.js
+++ b/test/index.js
@@ -22,3 +22,18 @@ b {
 test('sass should return a function', async t => {
   t.is(typeof sass(), 'function');
 });
+
+test('should append `data` passed', async t => {
+  const result = await preprocessSass({
+    data: '$color: red;',
+  }, {}, {
+    attributes: { lang: 'sass' },
+    filename: './src/components/App.html',
+    content: `b {
+  color: $color
+}`,
+  });
+  t.is(result.code, `b {
+  color: red; }
+`);
+});


### PR DESCRIPTION
The value passed as `data` will be added in front of the component's styles. This is useful if you want to define common variables for all your components.

Fixes #5