### PR TITLE
Some common uses and dependency doc links not covered in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ export default {
 
 Now all `<style>` elements in your components that have a `type="text/sass"` or `lang="sass"` attribute will be preprocessed by sass.
 
+If you are using `type="text/scss"` or `lang="scss"` then you will have to supply
+the `name` option as `scss`.
+
 ### Passing options to sass
 
 The `sass` function passes the first argument to the sass compiler, e.g.:
@@ -63,5 +66,9 @@ sass(
 )
 ```
 
-For available options visit [the sass documentation](http://sass-lang.com/documentation/).
+For available options visit the [sass](http://sass-lang.com/documentation/) and
+the [node-sass](https://github.com/sass/node-sass) documentation.
+
+> If you want to include scss from node_modules, you should supply the `includePaths`
+property in the `options`. i.e. `includePaths: ['src', 'node_modules']`.
 


### PR DESCRIPTION
I think a lot of people will be following docs from svelte, and therefore will use `lang="scss"` at the time of writing this.

While changing the source would be breaking, we can at least document it so that others understand what `name` actually does.

Also, the link to the sass docs does not represent the entire use of the sass options, as they are also used for node-sass(libsass), thus the `includePath` option is very useful to have in the README also.