### PR TITLE
feat: Detect indented syntax from language attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,8 @@ Now all `<style>` elements in your components that have a `type="text/sass"` or 
 <button on:click>Click me</button>
 ```
 
-<details><summary>
-
-**Note: Before version 1, you had to explicitly allow `scss` attributes**
-
-</summary>
+<details>
+<summary>Note: Before version 1, you had to explicitly allow `scss` attributes</summary>
 
 > From the old readme:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ Now all `<style>` elements in your components that have a `type="text/sass"` or 
 
 ### Using SCSS
 
+...just use `type="text/scss"` or `lang="scss"` in your components:
+
+```svelte
+<style type="text/scss">
+  $primary: red;
+
+  button {
+    color: $primary;
+  }
+</style>
+
+<button on:click>Click me</button>
+```
+
+<details><summary>
+
+**Note: Before version 1, you had to explicitly allow `scss` attributes**
+
+</summary>
+
+> From the old readme:
+
 If you prefer the non-indented syntax you have to supply the `name` option:
 
 ```js
@@ -70,19 +92,7 @@ export default {
 };
 ```
 
-...and use `type="text/scss"` or `lang="scss"` in your components:
-
-```svelte
-<style type="text/scss">
-  $primary: red;
-
-  button {
-    color: $primary;
-  }
-</style>
-
-<button on:click>Click me</button>
-```
+</details>
 
 ### Passing options to sass
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "rollup-plugin-node-resolve": "5.2.0"
   },
   "scripts": {
+    "build": "npm run -s compile",
     "compile": "rollup -c",
+    "dev": "rollup -cw",
     "lint": "eslint rollup.config.js src test",
     "test": "nyc ava"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,19 @@ export async function preprocessSass(
   filterOptions = {},
   { filename, content, attributes }
 ) {
-  if (!filter(Object.assign({ name: 'sass' }, filterOptions), { attributes })) { return null; }
+  // Detect if styles should be processed and in we should use sass (indented) syntax.
+  let indentedSyntax;
+  let processStyles;
+
+  if (filterOptions.name === undefined) {
+    indentedSyntax = filter({ name: 'sass', ...filterOptions }, { attributes });
+    processStyles = indentedSyntax || filter({ name: 'scss', ...filterOptions }, { attributes });
+  } else {
+    indentedSyntax = filterOptions.name === 'sass';
+    processStyles = filter(filterOptions, { attributes });
+  }
+
+  if (!processStyles) return null;
 
   const { css, map, stats } = await new Promise((resolve, reject) => sassCompiler.render({
     file: filename,
@@ -15,6 +27,7 @@ export async function preprocessSass(
     includePaths: [
       dirname(filename),
     ],
+    indentedSyntax,
     ...sassOptions,
   }, (err, result) => {
     if (err) {

--- a/test/index.js
+++ b/test/index.js
@@ -45,3 +45,8 @@ test('preprocessSass should use indented syntax if set in sassOptions', async t 
   t.is(await preprocess({ lang: 'scss' }, sampleSass, { indentedSyntax: true }), expected);
   t.is(await preprocess({ type: 'text/scss' }, sampleSass, { indentedSyntax: true }), expected);
 });
+
+test('preprocessSass should not detect sass with filterOptions', async t => {
+  t.is(await preprocessSass({}, { name: 'scss' }, { attributes: { lang: 'sass' } }), null);
+  t.is(await preprocessSass({}, { name: 'scss' }, { attributes: { type: 'text/sass' } }), null);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,24 +1,47 @@
 import test from 'ava';
 import { sass, preprocessSass } from '../src/index';
 
+async function preprocess(attributes, styles, sassOptions = {}, filterOptions = {}) {
+  return (await preprocessSass(sassOptions, filterOptions, {
+    attributes,
+    filename: './src/components/App.html',
+    content: styles,
+  })).code;
+}
+
+const sampleScss = `$color: red;
+b {
+  color: $color
+}`;
+
+const sampleSass = `$primary: red
+b
+  color: $primary`;
+
+const expected = `b {
+  color: red; }
+`;
+
 test('preprocessSass should filter non-sass styles', async t => {
   t.is(await preprocessSass({}, {}, { attributes: {} }), null);
 });
 
 test('preprocessSass should return preprocessed styles', async t => {
-  const result = await preprocessSass({}, {}, {
-    attributes: { lang: 'sass' },
-    filename: './src/components/App.html',
-    content: `$color: red;
-b {
-  color: $color
-}`,
-  });
-  t.is(result.code, `b {
-  color: red; }
-`);
+  t.is(await preprocess({ lang: 'scss' }, sampleScss), expected);
+  t.is(await preprocess({ type: 'text/scss' }, sampleScss), expected);
 });
 
 test('sass should return a function', async t => {
   t.is(typeof sass(), 'function');
+});
+
+test('preprocessSass should use indented syntax with language attribute set to "sass"', async t => {
+  t.is(await preprocess({ lang: 'sass' }, sampleSass), expected);
+  t.is(await preprocess({ type: 'text/sass' }, sampleSass), expected);
+});
+
+// Of course, using explicit sass in scss styles makes no sense at all 😅
+test('preprocessSass should use indented syntax if set in sassOptions', async t => {
+  t.is(await preprocess({ lang: 'scss' }, sampleSass, { indentedSyntax: true }), expected);
+  t.is(await preprocess({ type: 'text/scss' }, sampleSass, { indentedSyntax: true }), expected);
 });


### PR DESCRIPTION
You can now use `lang="sass"` or `type="text/sass"` to use indented syntax.

Fixes #98 